### PR TITLE
kubevirt_vm: Allow to specify template spec

### DIFF
--- a/examples/play-create-min.yml
+++ b/examples/play-create-min.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  tasks:
+    - name: Create VM
+      kubernetes.kubevirt.kubevirt_vm:
+        state: present
+        name: testvm
+        namespace: default
+        running: no

--- a/examples/play-create.yml
+++ b/examples/play-create.yml
@@ -11,26 +11,29 @@
           name: u1.medium
         preference:
           name: fedora
-        interfaces:
-        - name: default
-          masquerade: {}
-        - name: bridge-network
-          bridge: {}
-        networks:
-        - name: default
-          pod: {}
-        - name: bridge-network
-          multus:
-            networkName: kindexgw
-        volumes:
-        - containerDisk:
-            image: quay.io/containerdisks/fedora:latest
-          name: containerdisk
-        - cloudInitNoCloud:
-            userData: |-
-              #cloud-config
-              # The default username is: fedora
-              ssh_authorized_keys:
-                - ssh-ed25519 AAAA...
-          name: cloudinit
+        spec:
+          domain:
+            devices:
+              interfaces:
+              - name: default
+                masquerade: {}
+              - name: bridge-network
+                bridge: {}
+          networks:
+          - name: default
+            pod: {}
+          - name: bridge-network
+            multus:
+              networkName: kindexgw
+          volumes:
+          - containerDisk:
+              image: quay.io/containerdisks/fedora:latest
+            name: containerdisk
+          - cloudInitNoCloud:
+              userData: |-
+                #cloud-config
+                # The default username is: fedora
+                ssh_authorized_keys:
+                  - ssh-ed25519 AAAA...
+            name: cloudinit
         wait: yes

--- a/tests/unit/modules/test_module_kubevirt_vm.py
+++ b/tests/unit/modules/test_module_kubevirt_vm.py
@@ -70,7 +70,8 @@ spec:
     spec:
       domain:
         devices: {}
-      terminationGracePeriodSeconds: 180'''
+      terminationGracePeriodSeconds: 180
+'''
 
 FIXTURE2 = {
     'name': 'testvm',
@@ -80,11 +81,17 @@ FIXTURE2 = {
         'service': 'loadbalancer',
         'environment': 'staging'
     },
-    'api_version': 'kubevirt.io/v1', 'running': True, 'termination_grace_period': 180, 'wait': False, 'wait_sleep': 5, 'wait_timeout': 120, 'force': False,
-    'generate_name': None, 'annotations': None, 'instancetype': None, 'preference': None, 'interfaces': None, 'networks': None, 'volumes': None,
-    'kubeconfig': None, 'context': None, 'host': None, 'api_key': None, 'username': None, 'password': None, 'validate_certs': None, 'ca_cert': None,
-    'client_cert': None, 'client_key': None, 'proxy': None, 'no_proxy': None, 'proxy_headers': None, 'persist_config': None, 'impersonate_user': None,
-    'impersonate_groups': None, 'delete_options': None,
+    'spec': {
+        'domain': {
+            'devices': {}
+        },
+        'terminationGracePeriodSeconds': 180
+    },
+    'api_version': 'kubevirt.io/v1', 'running': True, 'wait': False, 'wait_sleep': 5, 'wait_timeout': 120, 'force': False,
+    'generate_name': None, 'annotations': None, 'instancetype': None, 'preference': None,
+    'kubeconfig': None, 'context': None, 'host': None, 'api_key': None, 'username': None, 'password': None, 'validate_certs': None,
+    'ca_cert': None, 'client_cert': None, 'client_key': None, 'proxy': None, 'no_proxy': None, 'proxy_headers': None,
+    'persist_config': None, 'impersonate_user': None, 'impersonate_groups': None, 'delete_options': None,
     'resource_definition': METADATA,
     'wait_condition': {
         'type': 'Ready',
@@ -127,6 +134,12 @@ class TestCreateVM(unittest.TestCase):
                 "labels": {
                     "service": "loadbalancer",
                     "environment": "staging"
+                },
+                'spec': {
+                    'domain': {
+                        'devices': {}
+                    },
+                    'terminationGracePeriodSeconds': 180
                 }
             }
         )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

By allowing to specify the template spec unnecessary abstraction is avoided.

The following module args are replaced by the 'spec' arg:
  - termination_grace_period
  - interfaces
  - networks
  - volumes

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```