### PR TITLE
kubevirt_vm: Allow to specify DataVolume templates

### DIFF
--- a/examples/play-create-dv.yml
+++ b/examples/play-create-dv.yml
@@ -1,0 +1,41 @@
+- hosts: localhost
+  tasks:
+    - name: Create VM
+      kubernetes.kubevirt.kubevirt_vm:
+        state: present
+        name: testvm-with-dv
+        namespace: default
+        labels:
+          app: test
+        instancetype:
+          name: u1.medium
+        preference:
+          name: fedora
+        data_volume_templates:
+          - metadata:
+              name: testdv
+            spec:
+              source:
+                registry:
+                  url: docker://quay.io/containerdisks/fedora:latest
+              storage:
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 5Gi
+        spec:
+          domain:
+            devices: {}
+          volumes:
+          - dataVolume:
+              name: testdv
+            name: datavolume
+          - cloudInitNoCloud:
+              userData: |-
+                #cloud-config
+                # The default username is: fedora
+                ssh_authorized_keys:
+                  - ssh-ed25519 AAAA...
+            name: cloudinit
+        wait: yes

--- a/examples/play-delete-dv.yml
+++ b/examples/play-delete-dv.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  tasks:
+    - name: Delete VM
+      kubernetes.kubevirt.kubevirt_vm:
+        name: testvm-with-dv
+        namespace: default
+        state: absent
+        wait: yes

--- a/hack/e2e-setup.sh
+++ b/hack/e2e-setup.sh
@@ -29,6 +29,7 @@ set_default_params() {
   KUBECTL_VERSION=${KUBECTL_VERSION:-v1.27.3}
 
   KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v1.0.0}
+  KUBEVIRT_CDI_VERSION=${KUBEVIRT_CDI_VERSION:-v1.56.0}
   KUBEVIRT_COMMON_INSTANCETYPES_VERSION=${KUBEVIRT_COMMON_INSTANCETYPES_VERSION:-v0.3.0}
   KUBEVIRT_USE_EMULATION=${KUBEVIRT_USE_EMULATION:-"false"}
 
@@ -175,6 +176,12 @@ is_nested_virt_enabled() {
   [ "$kvm_nested" == "1" ] || [ "$kvm_nested" == "Y" ] || [ "$kvm_nested" == "y" ]
 }
 
+deploy_kubevirt_containerized_data_importer() {
+  echo "Deploying KubeVirt containerized-data-importer"
+  ${KUBECTL} apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${KUBEVIRT_CDI_VERSION}/cdi-operator.yaml"
+  ${KUBECTL} apply -f "https://github.com/kubevirt/containerized-data-importer/releases/download/${KUBEVIRT_CDI_VERSION}/cdi-cr.yaml"
+}
+
 deploy_kubevirt_common_instancetypes() {
   echo "Deploying KubeVirt common-instancetypes"
   ${KUBECTL} apply -f "https://github.com/kubevirt/common-instancetypes/releases/download/${KUBEVIRT_COMMON_INSTANCETYPES_VERSION}/common-instancetypes-all-bundle-${KUBEVIRT_COMMON_INSTANCETYPES_VERSION}.yaml"
@@ -255,6 +262,7 @@ set_default_options() {
   OPT_CREATE_CLUSTER=false
   OPT_CONFIGURE_SECONDARY_NETWORK=false
   OPT_DEPLOY_KUBEVIRT=false
+  OPT_DEPLOY_KUBEVIRT_CDI=false
   OPT_DEPLOY_KUBEVIRT_COMMON_INSTANCETYPES=false
   OPT_DEPLOY_CNAO=false
   OPT_CREATE_NAD=false
@@ -270,6 +278,7 @@ parse_args() {
     --create-cluster) OPT_CREATE_CLUSTER=true ;;
     --configure-secondary-network) OPT_CONFIGURE_SECONDARY_NETWORK=true ;;
     --deploy-kubevirt) OPT_DEPLOY_KUBEVIRT=true ;;
+    --deploy-kubevirt-cdi) OPT_DEPLOY_KUBEVIRT_CDI=true ;;
     --deploy-kubevirt-common-instancetypes) OPT_DEPLOY_KUBEVIRT_COMMON_INSTANCETYPES=true ;;
     --deploy-cnao) OPT_DEPLOY_CNAO=true ;;
     --create-nad) OPT_CREATE_NAD=true ;;
@@ -310,6 +319,7 @@ if [ "${ARGCOUNT}" -eq "0" ]; then
   OPT_CREATE_CLUSTER=true
   OPT_CONFIGURE_SECONDARY_NETWORK=true
   OPT_DEPLOY_KUBEVIRT=true
+  OPT_DEPLOY_KUBEVIRT_CDI=true
   OPT_DEPLOY_KUBEVIRT_COMMON_INSTANCETYPES=true
   OPT_DEPLOY_CNAO=true
   OPT_CREATE_NAD=true
@@ -342,6 +352,10 @@ fi
 
 if [ "${OPT_DEPLOY_KUBEVIRT}" == true ]; then
   deploy_kubevirt
+fi
+
+if [ "${OPT_DEPLOY_KUBEVIRT_CDI}" == true ]; then
+  deploy_kubevirt_containerized_data_importer
 fi
 
 if [ "${OPT_DEPLOY_KUBEVIRT_COMMON_INSTANCETYPES}" == true ]; then

--- a/tests/unit/modules/test_module_kubevirt_vm.py
+++ b/tests/unit/modules/test_module_kubevirt_vm.py
@@ -35,6 +35,30 @@ FIXTURE1 = {
     },
     "spec": {
         "running": True,
+        "dataVolumeTemplates": [
+            {
+                "metadata": {
+                    "name": "testdv"
+                },
+                "spec": {
+                    "source": {
+                        "registry": {
+                            "url": "docker://quay.io/containerdisks/fedora:latest"
+                        },
+                    },
+                    "storage": {
+                        "accessModes": [
+                            "ReadWriteOnce"
+                        ],
+                        "resources": {
+                            "requests": {
+                                "storage": "5Gi"
+                            }
+                        }
+                    }
+                }
+            }
+        ],
         "template": {
             "metadata": {
                 "labels": {
@@ -62,6 +86,19 @@ metadata:
     service: loadbalancer
 spec:
   running: True
+  dataVolumeTemplates:
+    - metadata:
+        name: testdv
+      spec:
+        source:
+          registry:
+            url: docker://quay.io/containerdisks/fedora:latest
+        storage:
+          accessModes:
+          - ReadWriteOnce
+          resources:
+            requests:
+              storage: 5Gi
   template:
     metadata:
       labels:
@@ -81,6 +118,30 @@ FIXTURE2 = {
         'service': 'loadbalancer',
         'environment': 'staging'
     },
+    'data_volume_templates': [
+        {
+            'metadata': {
+                'name': 'testdv'
+            },
+            'spec': {
+                'source': {
+                    'registry': {
+                        'url': 'docker://quay.io/containerdisks/fedora:latest'
+                    },
+                },
+                'storage': {
+                    'accessModes': [
+                        'ReadWriteOnce'
+                    ],
+                    'resources': {
+                        'requests': {
+                            'storage': '5Gi'
+                        }
+                    }
+                }
+            }
+        }
+    ],
     'spec': {
         'domain': {
             'devices': {}
@@ -135,6 +196,30 @@ class TestCreateVM(unittest.TestCase):
                     "service": "loadbalancer",
                     "environment": "staging"
                 },
+                'data_volume_templates': [
+                    {
+                        'metadata': {
+                            'name': 'testdv'
+                        },
+                        'spec': {
+                            'source': {
+                                'registry': {
+                                    'url': 'docker://quay.io/containerdisks/fedora:latest'
+                                },
+                            },
+                            'storage': {
+                                'accessModes': [
+                                    'ReadWriteOnce'
+                                ],
+                                'resources': {
+                                    'requests': {
+                                        'storage': '5Gi'
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
                 'spec': {
                     'domain': {
                         'devices': {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

By allowing to specify DataVolume templates VMs with persistent storage
can be created using the kubevirt_vm module.

**Special notes for your reviewer**:

Examples and docs will only be valid after #1 and #3 were merged.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```