### PR TITLE
kubevirt_vm: Prevent unnecessary whitespace

### DIFF
--- a/plugins/modules/kubevirt_vm.py
+++ b/plugins/modules/kubevirt_vm.py
@@ -284,11 +284,11 @@ spec:
   {% if instancetype %}
   instancetype:
     {{ instancetype | to_yaml | indent(4) }}
-  {% endif %}
+  {%- endif %}
   {% if preference %}
   preference:
     {{ preference | to_yaml | indent(4) }}
-  {% endif %}
+  {%- endif %}
   {% if data_volume_templates %}
   dataVolumeTemplates:
     {{ data_volume_templates | to_yaml | indent(4) }}

--- a/tests/unit/modules/test_module_kubevirt_vm.py
+++ b/tests/unit/modules/test_module_kubevirt_vm.py
@@ -35,6 +35,12 @@ FIXTURE1 = {
     },
     "spec": {
         "running": True,
+        "instancetype": {
+            "name": "u1.medium"
+        },
+        "preference": {
+            "name": "fedora"
+        },
         "dataVolumeTemplates": [
             {
                 "metadata": {
@@ -86,6 +92,10 @@ metadata:
     service: loadbalancer
 spec:
   running: True
+  instancetype:
+    name: u1.medium
+  preference:
+    name: fedora
   dataVolumeTemplates:
     - metadata:
         name: testdv
@@ -118,6 +128,12 @@ FIXTURE2 = {
         'service': 'loadbalancer',
         'environment': 'staging'
     },
+    'instancetype': {
+        'name': 'u1.medium'
+    },
+    'preference': {
+        'name': 'fedora'
+    },
     'data_volume_templates': [
         {
             'metadata': {
@@ -149,10 +165,10 @@ FIXTURE2 = {
         'terminationGracePeriodSeconds': 180
     },
     'api_version': 'kubevirt.io/v1', 'running': True, 'wait': False, 'wait_sleep': 5, 'wait_timeout': 120, 'force': False,
-    'generate_name': None, 'annotations': None, 'instancetype': None, 'preference': None,
-    'kubeconfig': None, 'context': None, 'host': None, 'api_key': None, 'username': None, 'password': None, 'validate_certs': None,
-    'ca_cert': None, 'client_cert': None, 'client_key': None, 'proxy': None, 'no_proxy': None, 'proxy_headers': None,
-    'persist_config': None, 'impersonate_user': None, 'impersonate_groups': None, 'delete_options': None,
+    'generate_name': None, 'annotations': None, 'kubeconfig': None, 'context': None, 'host': None, 'api_key': None,
+    'username': None, 'password': None, 'validate_certs': None, 'ca_cert': None, 'client_cert': None, 'client_key': None,
+    'proxy': None, 'no_proxy': None, 'proxy_headers': None, 'persist_config': None, 'impersonate_user': None,
+    'impersonate_groups': None, 'delete_options': None,
     'resource_definition': METADATA,
     'wait_condition': {
         'type': 'Ready',
@@ -195,6 +211,12 @@ class TestCreateVM(unittest.TestCase):
                 "labels": {
                     "service": "loadbalancer",
                     "environment": "staging"
+                },
+                'instancetype': {
+                    'name': 'u1.medium'
+                },
+                'preference': {
+                    'name': 'fedora'
                 },
                 'data_volume_templates': [
                     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This removes the unnecessary whitespace from the rendered VirtualMachine
template and adds a unit test for it.

**Special notes for your reviewer**:

Merge after #4

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
